### PR TITLE
Fix distributed variable importance producing all zeros with small OOB

### DIFF
--- a/R/RLT.r
+++ b/R/RLT.r
@@ -372,6 +372,9 @@ RLT <- function(x, y, censor = NULL, model = NULL,
   # check control parameters
   param.control = check_control(param.control, param)
 
+  # check importance feasibility (OOB size vs importance type)
+  check_importance_settings(importance, n, resample.replace, resample.prob)
+
   # reset some parameters if var.mode is needed
   if (param.control$var.mode != "none")
   {

--- a/R/check.r
+++ b/R/check.r
@@ -135,6 +135,48 @@ check_importance <- function(importance)
   return(importance.num)
 }
 
+check_importance_settings <- function(importance, n, resample.replace, resample.prob)
+{
+  if (importance == 0) return(invisible(NULL))
+  
+  # expected OOB size
+  oob_size <- n - as.integer(n * resample.prob)
+  
+  if (resample.replace)
+  {
+    # bootstrap always has OOB; just check n is not tiny
+    if (n < 3)
+      warning(sprintf(
+        "n = %d is very small; importance estimates may be unreliable.",
+        n), call. = FALSE)
+    return(invisible(NULL))
+  }
+  
+  # no replacement: OOB size is deterministic
+  if (importance == 1 && oob_size < 2)
+  {
+    warning(sprintf(
+      "Permutation importance requires at least 2 OOB observations per tree, but current settings yield only %d (n = %d, resample.prob = %.4f, resample.replace = FALSE). Importance calculation will be skipped. Consider increasing OOB by lowering resample.prob or using resample.replace = TRUE.",
+      oob_size, n, resample.prob), call. = FALSE)
+  }
+  
+  if (importance == 2 && oob_size < 1)
+  {
+    warning(sprintf(
+      "Distributed importance requires at least 1 OOB observation per tree, but current settings yield 0 (n = %d, resample.prob = %.4f, resample.replace = FALSE). Importance calculation will be skipped. Consider lowering resample.prob.",
+      n, resample.prob), call. = FALSE)
+  }
+  
+  if (importance == 2 && oob_size >= 1 && oob_size < 5)
+  {
+    warning(sprintf(
+      "Distributed importance with only %d OOB observation(s) per tree (n = %d, resample.prob = %.4f) may produce noisy estimates. Consider using more OOB samples (e.g., resample.prob = 0.632 with resample.replace = FALSE).",
+      oob_size, n, resample.prob), call. = FALSE)
+  }
+  
+  invisible(NULL)
+}
+
 
 check_reinforcement <- function(reinforcement)
 {

--- a/src/classification/Cla_Uni_0_Forest_Build.cpp
+++ b/src/classification/Cla_Uni_0_Forest_Build.cpp
@@ -47,9 +47,14 @@ void Cla_Uni_Forest_Build(const RLT_CLA_DATA& CLA_DATA,
     ObsTrack.zeros(N, ntrees);
   
   // oob sample too small, turn off importance
-  // Only applies to non-replacement sampling (replacement always has ~36.8% OOB)
-  if (!replacement && N - size < 2)
-    importance = 0;
+  // permutation importance needs >= 2 OOB; distributed needs >= 1 OOB
+  if (!replacement && importance > 0)
+  {
+    if (importance == 1 && N - size < 2)
+      importance = 0;
+    else if (importance == 2 && N - size < 1)
+      importance = 0;
+  }
   
   // Calculate predictions
   
@@ -191,7 +196,7 @@ void Cla_Uni_Forest_Build(const RLT_CLA_DATA& CLA_DATA,
       }
 
       // probability variable importance
-      if (importance == 2 and NTest > 1)
+      if (importance == 2 and NTest > 0)
       {
         uvec oobY = CLA_DATA.Y(oobag_id);
         

--- a/src/regression/Reg_Uni_0_Forest_Build.cpp
+++ b/src/regression/Reg_Uni_0_Forest_Build.cpp
@@ -46,9 +46,14 @@ void Reg_Uni_Forest_Build(const RLT_REG_DATA& REG_DATA,
     ObsTrack.zeros(N, ntrees);
   
   // oob sample too small, turn off importance
-  // Only applies to non-replacement sampling (replacement always has ~36.8% OOB)
-  if (!replacement && N - size < 2)
-    importance = 0;
+  // permutation importance needs >= 2 OOB; distributed needs >= 1 OOB
+  if (!replacement && importance > 0)
+  {
+    if (importance == 1 && N - size < 2)
+      importance = 0;
+    else if (importance == 2 && N - size < 1)
+      importance = 0;
+  }
   
   // Calculate predictions
   
@@ -179,7 +184,7 @@ void Reg_Uni_Forest_Build(const RLT_REG_DATA& REG_DATA,
       }
       
       // probability variable importance
-      if (importance == 2 and NTest > 1)
+      if (importance == 2 and NTest > 0)
       {
         vec oobY = REG_DATA.Y(oobag_id);
         

--- a/src/survival/Surv_Uni_0_Forest_Build.cpp
+++ b/src/survival/Surv_Uni_0_Forest_Build.cpp
@@ -47,9 +47,14 @@ void Surv_Uni_Forest_Build(const RLT_SURV_DATA& SURV_DATA,
     ObsTrack.zeros(N, ntrees);
   
   // oob sample too small, turn off importance
-  // Only applies to non-replacement sampling (replacement always has ~36.8% OOB)
-  if (!replacement && N - size < 2)
-    importance = 0;
+  // permutation importance needs >= 2 OOB; distributed needs >= 1 OOB
+  if (!replacement && importance > 0)
+  {
+    if (importance == 1 && N - size < 2)
+      importance = 0;
+    else if (importance == 2 && N - size < 1)
+      importance = 0;
+  }
   
   // 
   if (importance) do_prediction = true;
@@ -204,7 +209,7 @@ void Surv_Uni_Forest_Build(const RLT_SURV_DATA& SURV_DATA,
       }
       
       // probability variable importance (distribute)
-      if (importance == 2 and NTest > 1)
+      if (importance == 2 and NTest > 0)
       {
         // oob samples
         uvec oobY = SURV_DATA.Y(oobag_id);

--- a/vignettes/articles/variable-importance.Rmd
+++ b/vignettes/articles/variable-importance.Rmd
@@ -107,17 +107,17 @@ barplot(
 
 ## Option B - Distributed Assignment Importance
 
-This configuration assigns importance using distributed attribution with OOB tracking. Use `importance = "distribute"` for distributed assignment importance.
+This configuration assigns importance using distributed attribution with OOB tracking. Use `importance = "distribute"` for distributed assignment importance. Unlike permutation importance, distributed importance works by probabilistically routing OOB observations through the tree when a split on the target variable is encountered. This requires sufficient OOB samples per tree — avoid very high `resample.prob` with `resample.replace = FALSE`, which leaves too few OOB observations.
+
 ```{r dist-importance}
 fit_dist <- RLT(
   trainX, trainY, model = "regression",
   ntrees = ntrees, mtry = mtry, nmin = nmin,
   split.gen = rule, nsplit = nsplit,
-  resample.prob = (trainn - 1)/trainn,   # leave-one-out style OOB
-  resample.replace = FALSE,               # without replacement
-  importance = "distribute",              # distributed assignment VI
-  ncores = ncores, verbose = FALSE,
-  param.control = list("resample.track" = TRUE)
+  resample.prob = 0.632,                # ~63.2% in-bag, ~36.8% OOB
+  resample.replace = FALSE,              # without replacement
+  importance = "distribute",             # distributed assignment VI
+  ncores = ncores, verbose = FALSE
 )
 
 # VI vector lives in fit$VarImp


### PR DESCRIPTION
## Problem

The [Variable Importance vignette](https://teazrq.github.io/RLT/articles/variable-importance.html) shows distributed importance as all zeros.

Two compounding bugs:

1. **C++ early-exit guard** (`N - size < 2`) silently disabled ALL importance types when OOB < 2. Distributed importance only needs OOB ≥ 1 (each observation is processed independently), unlike permutation which needs ≥ 2.

2. **C++ per-tree guard** (`NTest > 1`) also blocked the distributed calculation at the per-tree level.

3. **No R-level validation** — users got no warning about incompatible settings.

The vignette used `resample.prob = (n-1)/n` with `resample.replace = FALSE`, leaving only 1 OOB observation per tree, triggering both guards.

## Changes

| File | Change |
|---|---|
| `R/check.r` | New `check_importance_settings()` — warns when OOB is too small for the requested importance type (permute ≥ 2, distribute ≥ 1, soft warning for distribute with < 5) |
| `R/RLT.r` | Calls `check_importance_settings()` after parameter assembly |
| `src/{regression,classification,survival}/*_0_Forest_Build.cpp` | Early-exit guard now distinguishes importance types; per-tree distributed guard relaxed to `NTest > 0` |
| `vignettes/articles/variable-importance.Rmd` | Fixed example: `resample.prob = 0.632` with `resample.replace = FALSE`; added note about OOB requirements |

## Testing

- All three models (regression, classification, survival) produce correct non-zero distributed importance
- Old vignette settings (1 OOB) now produce results (with a warning about noisiness)
- Permutation importance with too-small OOB properly warns and skips