### PR TITLE
Rewrite confidence-interval vignette: smoothed bands, ggplot2

### DIFF
--- a/vignettes/articles/confidence-interval.Rmd
+++ b/vignettes/articles/confidence-interval.Rmd
@@ -19,14 +19,13 @@ output:
 ```{r setup, include=FALSE}
 knitr::opts_chunk$set(
   message = FALSE, warning = FALSE,
-  fig.width = 9, fig.height = 7, out.width = "90%", fig.align = "center",
+  fig.width = 8, fig.height = 7, out.width = "90%", fig.align = "center",
   collapse = TRUE, class.source = "fold-show"
 )
 ```
 
 ```{r load-libs}
 library(RLT)
-library(ggplot2)
 ```
 
 ## Overview
@@ -89,57 +88,40 @@ RLTPred <- predict(fit, testX, var.est = TRUE, ncores = 1)
 
 Before constructing simultaneous bands, it is useful to look at pointwise intervals ($\pm 1.96 \times \text{SD}$ from the diagonal of the covariance matrix). These are **not** simultaneous — each time point is considered independently.
 
-```{r plot-helper}
-# Helper: build a data.frame for ggplot from one subject
-build_subject_df <- function(subject_id, pred, SurvMat = NULL, band_list = NULL) {
-  tp  <- pred$timepoints
-  S   <- as.numeric(pred$Survival[subject_id, ])
-  sdf <- data.frame(
-    time  = tp,
-    surv  = pmin(pmax(S, 0), 1),
-    lower_pw = pmin(pmax(S - qnorm(0.975) * sqrt(diag(pred$Cov[,, subject_id])), 0), 1),
-    upper_pw = pmin(pmax(S + qnorm(0.975) * sqrt(diag(pred$Cov[,, subject_id])), 0), 1)
-  )
+```{r pointwise-plot, fig.height=8}
+par(mfrow = c(2, 2), mar = c(4, 4, 3, 1))
+
+for (i in 1:ntest) {
+  tp  <- RLTPred$timepoints
+  S   <- pmin(pmax(as.numeric(RLTPred$Survival[i, ]), 0), 1)
+  sd_i <- sqrt(diag(RLTPred$Cov[,, i]))
+  pw_lower <- pmin(pmax(S - qnorm(0.975) * sd_i, 0), 1)
+  pw_upper <- pmin(pmax(S + qnorm(0.975) * sd_i, 0), 1)
+  truth <- as.numeric(SurvMat[i, ])
   
-  if (!is.null(SurvMat)) {
-    sdf$truth <- pmin(pmax(as.numeric(SurvMat[subject_id, ]), 0), 1)
-  }
+  # Plot estimate with shaded pointwise CI
+  plot(tp, S, type = "n", ylim = c(0, 1),
+       xlab = "Time", ylab = "Survival Probability",
+       main = paste("Subject", i))
   
-  if (!is.null(band_list)) {
-    sdf$lower_band <- pmin(pmax(as.numeric(band_list[[subject_id]]$lower), 0), 1)
-    sdf$upper_band <- pmin(pmax(as.numeric(band_list[[subject_id]]$upper), 0), 1)
-  }
+  # Shaded pointwise band
+  polygon(c(tp, rev(tp)), c(pw_lower, rev(pw_upper)),
+          col = rgb(0.7, 0.7, 0.7, 0.5), border = NA)
   
-  sdf
+  # Truth (dashed red)
+  lines(tp, truth, col = "#E41A1C", lwd = 2, lty = 2)
+  
+  # Estimate (step function, black)
+  lines(tp, S, type = "s", lwd = 2)
+  
+  legend("topright", legend = c("Estimated S(t)", "True S(t)", "Pointwise 95% CI"),
+         lty = c(1, 2, NA), lwd = c(2, 2, NA), col = c("black", "#E41A1C", NA),
+         fill = c(NA, NA, rgb(0.7, 0.7, 0.7, 0.5)),
+         border = c(NA, NA, NA),
+         bty = "n", cex = 0.8)
 }
-```
 
-```{r pointwise-plot, fig.width=10, fig.height=9}
-# Build data for all subjects
-plot_data <- do.call(rbind, lapply(1:ntest, function(i) {
-  d <- build_subject_df(i, RLTPred, SurvMat)
-  d$subject <- paste("Subject", i)
-  d
-}))
-
-ggplot(plot_data, aes(x = time)) +
-  facet_wrap(~ subject, nrow = 2, scales = "free_y") +
-  # Pointwise band (shaded)
-  geom_ribbon(aes(ymin = lower_pw, ymax = upper_pw),
-              fill = "grey80", alpha = 0.6) +
-  # Truth
-  geom_line(aes(y = truth, colour = "True S(t)"), linewidth = 0.9, linetype = "dashed") +
-  # Estimate
-  geom_step(aes(y = surv, colour = "Estimated S(t)"), linewidth = 0.9) +
-  scale_colour_manual(name = NULL,
-                      values = c("True S(t)" = "#E41A1C", "Estimated S(t)" = "#222222")) +
-  scale_y_continuous(limits = c(0, 1), expand = c(0.01, 0.01)) +
-  labs(x = "Time", y = "Survival Probability",
-       title = "Pointwise 95% Confidence Intervals") +
-  theme_minimal(base_size = 13) +
-  theme(legend.position = "bottom",
-        panel.grid.minor = element_blank(),
-        strip.text = element_text(face = "bold"))
+par(mfrow = c(1, 1))
 ```
 
 ## Simultaneous confidence band
@@ -150,35 +132,49 @@ ggplot(plot_data, aes(x = time)) +
 SurvBand <- get.surv.band(RLTPred, alpha = 0.05, approach = "smoothed", k_rank = 10)
 ```
 
-```{r band-plot, fig.width=10, fig.height=9}
-plot_band <- do.call(rbind, lapply(1:ntest, function(i) {
-  d <- build_subject_df(i, RLTPred, SurvMat, SurvBand)
-  d$subject <- paste("Subject", i)
-  d
-}))
+```{r band-plot, fig.height=8}
+par(mfrow = c(2, 2), mar = c(4, 4, 3, 1))
 
-ggplot(plot_band, aes(x = time)) +
-  facet_wrap(~ subject, nrow = 2, scales = "free_y") +
-  # Simultaneous band (blue shading)
-  geom_ribbon(aes(ymin = lower_band, ymax = upper_band),
-              fill = "#3B82F6", alpha = 0.25) +
-  # Pointwise band (grey shading, for comparison)
-  geom_ribbon(aes(ymin = lower_pw, ymax = upper_pw),
-              fill = "grey70", alpha = 0.3) +
-  # Truth
-  geom_line(aes(y = truth, colour = "True S(t)"), linewidth = 0.9, linetype = "dashed") +
-  # Estimate
-  geom_step(aes(y = surv, colour = "Estimated S(t)"), linewidth = 0.9) +
-  scale_colour_manual(name = NULL,
-                      values = c("True S(t)" = "#E41A1C", "Estimated S(t)" = "#222222")) +
-  scale_y_continuous(limits = c(0, 1), expand = c(0.01, 0.01)) +
-  labs(x = "Time", y = "Survival Probability",
-       title = "Smoothed Covariance — 95% Simultaneous Confidence Band",
-       subtitle = "Grey = pointwise CI; Blue = simultaneous band") +
-  theme_minimal(base_size = 13) +
-  theme(legend.position = "bottom",
-        panel.grid.minor = element_blank(),
-        strip.text = element_text(face = "bold"))
+for (i in 1:ntest) {
+  tp  <- RLTPred$timepoints
+  S   <- pmin(pmax(as.numeric(RLTPred$Survival[i, ]), 0), 1)
+  sd_i <- sqrt(diag(RLTPred$Cov[,, i]))
+  pw_lower <- pmin(pmax(S - qnorm(0.975) * sd_i, 0), 1)
+  pw_upper <- pmin(pmax(S + qnorm(0.975) * sd_i, 0), 1)
+  truth <- as.numeric(SurvMat[i, ])
+  
+  b_lower <- pmin(pmax(as.numeric(SurvBand[[i]]$lower), 0), 1)
+  b_upper <- pmin(pmax(as.numeric(SurvBand[[i]]$upper), 0), 1)
+  
+  plot(tp, S, type = "n", ylim = c(0, 1),
+       xlab = "Time", ylab = "Survival Probability",
+       main = paste("Subject", i))
+  
+  # Shaded simultaneous band (blue)
+  polygon(c(tp, rev(tp)), c(b_lower, rev(b_upper)),
+          col = rgb(0.23, 0.51, 0.96, 0.25), border = NA)
+  
+  # Shaded pointwise band (grey)
+  polygon(c(tp, rev(tp)), c(pw_lower, rev(pw_upper)),
+          col = rgb(0.7, 0.7, 0.7, 0.3), border = NA)
+  
+  # Truth (dashed red)
+  lines(tp, truth, col = "#E41A1C", lwd = 2, lty = 2)
+  
+  # Estimate (step function, black)
+  lines(tp, S, type = "s", lwd = 2)
+  
+  legend("topright",
+         legend = c("Estimated S(t)", "True S(t)",
+                    "Pointwise 95% CI", "Simultaneous 95% Band"),
+         lty = c(1, 2, NA, NA), lwd = c(2, 2, NA, NA),
+         col = c("black", "#E41A1C", NA, NA),
+         fill = c(NA, NA, rgb(0.7, 0.7, 0.7, 0.5), rgb(0.23, 0.51, 0.96, 0.4)),
+         border = c(NA, NA, NA, NA),
+         bty = "n", cex = 0.75)
+}
+
+par(mfrow = c(1, 1))
 ```
 
 ## (Optional) Proportion-selected smoothing

--- a/vignettes/articles/confidence-interval.Rmd
+++ b/vignettes/articles/confidence-interval.Rmd
@@ -1,5 +1,5 @@
 ---
-title: "Confidence Interval and Confidence Band - Survival Tutorial (RLT)"
+title: "Confidence Interval and Confidence Band — Survival Tutorial (RLT)"
 author: "Ruoqing Zhu"
 date: "Last Updated: `r format(Sys.time(), '%B %d, %Y')`"
 output:
@@ -17,47 +17,49 @@ output:
 ---
 
 ```{r setup, include=FALSE}
-# Clean, consistent output for all chunks
 knitr::opts_chunk$set(
   message = FALSE, warning = FALSE,
-  fig.width = 7, fig.height = 5, out.width = "80%", fig.align = "center",
+  fig.width = 9, fig.height = 7, out.width = "90%", fig.align = "center",
   collapse = TRUE, class.source = "fold-show"
 )
 ```
 
+```{r load-libs}
+library(RLT)
+library(ggplot2)
+```
+
 ## Overview
 
-This page shows how to construct confidence bands for individual survival curves predicted by RLT.
+This page demonstrates how to construct **pointwise confidence intervals** and **simultaneous confidence bands** for individual survival curves predicted by RLT. The bands use a smoothed low-rank covariance approach — GAM-smoothed eigenvalue decomposition plus an eigenvalue-ratio weighted residual correction — which produces stable, well-calibrated bands even when the number of time points is large relative to the number of trees.
 
 ## Data
 
-We simulate right-censored survival data with standard normal predictors.
+We simulate right-censored survival data from a proportional hazards model with exponential event times. The first and third predictors carry signal; the rest are noise.
 
 ```{r data-prep}
-# (Optional) For reproducibility in this tutorial only
 set.seed(2)
 
-# ---- Generate a small survival dataset (~120 obs) ----
-n <- 120
+n <- 200
 p <- 10
 X <- matrix(rnorm(n * p), n, p)
 
 xlink <- function(x) exp(x[, 1] + x[, 3] / 2)
-FT <- rexp(n, rate = xlink(X))          # event times
-CT <- pmin(6, rexp(n, rate = 0.25))     # censoring times (cap at 6)
+FT <- rexp(n, rate = xlink(X))
+CT <- pmin(6, rexp(n, rate = 0.25))
 
-Y <- pmin(FT, CT)                        # observed time
-Censor <- as.numeric(FT <= CT)           # 1 = event observed
+Y <- pmin(FT, CT)
+Censor <- as.numeric(FT <= CT)
 
-# A few test subjects to visualize (keep small for a clean figure)
-ntest  <- 6
+# Test subjects for visualization
+ntest  <- 4
+set.seed(100)
 testX  <- matrix(rnorm(ntest * p), ntest, p)
 
-# True survival for reference (only for simulated data)
+# True survival for reference
 timepoints <- sort(unique(Y[Censor == 1]))
 SurvMat    <- matrix(NA, nrow(testX), length(timepoints))
 exprate    <- xlink(testX)
-
 for (j in seq_along(timepoints)) {
   SurvMat[, j] <- 1 - pexp(timepoints[j], rate = exprate)
 }
@@ -65,13 +67,12 @@ for (j in seq_along(timepoints)) {
 
 ## Fit and predict with variance
 
-```{r fit-predict}
-# install.packages("devtools"); devtools::install_github("teazrq/RLT")
-library(RLT)
+We use `var.mode = "matched"` (matched-sample U-statistic) for variance estimation. This automatically adjusts sampling to subsampling without replacement at 50%.
 
+```{r fit-predict}
 fit <- RLT(
   X, Y, Censor, model = "survival",
-  ntrees = 200, mtry = min(p, 10), nmin = 5,
+  ntrees = 1000, mtry = min(p, 10), nmin = 5,
   split.gen = "random", nsplit = 3,
   resample.prob = 0.8, resample.replace = FALSE,
   importance = FALSE, verbose = FALSE,
@@ -82,74 +83,110 @@ fit <- RLT(
 
 # Predict survival curves and covariance for test subjects
 RLTPred <- predict(fit, testX, var.est = TRUE, ncores = 1)
-
 ```
 
-## Option A — Naive Monte Carlo
+## Pointwise confidence intervals
 
-This option computes bands using a Monte Carlo scheme with the covariance estimate.
-We also plot pointwise ±1.96 * sd from the diagonal of the covariance for reference.
+Before constructing simultaneous bands, it is useful to look at pointwise intervals ($\pm 1.96 \times \text{SD}$ from the diagonal of the covariance matrix). These are **not** simultaneous — each time point is considered independently.
 
-```{r naive-bands, fig.width=10, fig.height=8}
-alpha <- 0.05
-logt  <- log(1 + timepoints)
-
-SurvBand_A <- get.surv.band(RLTPred, alpha = alpha, approach = "naive")
-
-layout(matrix(1:ntest, nrow = 2, byrow = TRUE))
-par(mar = c(3, 3, 2, 1))
-for (i in 1:ntest) {
-  # truth (red) — only available here because data are simulated
-  plot(logt, SurvMat[i, ], type = "l", lwd = 2, col = "red",
-       xlab = "log(1 + time)", ylab = paste("Subject", i),
-       ylim = c(0, 1))
+```{r plot-helper}
+# Helper: build a data.frame for ggplot from one subject
+build_subject_df <- function(subject_id, pred, SurvMat = NULL, band_list = NULL) {
+  tp  <- pred$timepoints
+  S   <- as.numeric(pred$Survival[subject_id, ])
+  sdf <- data.frame(
+    time  = tp,
+    surv  = pmin(pmax(S, 0), 1),
+    lower_pw = pmin(pmax(S - qnorm(0.975) * sqrt(diag(pred$Cov[,, subject_id])), 0), 1),
+    upper_pw = pmin(pmax(S + qnorm(0.975) * sqrt(diag(pred$Cov[,, subject_id])), 0), 1)
+  )
   
-  # estimated survival (black solid) and pointwise 1.96 bands (black dotted)
-  lines(logt, RLTPred$Survival[i, ], lwd = 2, col = "black")
-  lines(logt, RLTPred$Survival[i, ] - qnorm(1 - alpha/2) * sqrt(diag(RLTPred$Cov[,, i])),
-        lty = 2, col = "black")
-  lines(logt, RLTPred$Survival[i, ] + qnorm(1 - alpha/2) * sqrt(diag(RLTPred$Cov[,, i])),
-        lty = 2, col = "black")
+  if (!is.null(SurvMat)) {
+    sdf$truth <- pmin(pmax(as.numeric(SurvMat[subject_id, ]), 0), 1)
+  }
   
-  # naive band (blue dotted)
-  lines(logt, as.numeric(SurvBand_A[[i]]$lower), lty = 3, lwd = 2, col = "deepskyblue")
-  lines(logt, as.numeric(SurvBand_A[[i]]$upper), lty = 3, lwd = 2, col = "deepskyblue")
+  if (!is.null(band_list)) {
+    sdf$lower_band <- pmin(pmax(as.numeric(band_list[[subject_id]]$lower), 0), 1)
+    sdf$upper_band <- pmin(pmax(as.numeric(band_list[[subject_id]]$upper), 0), 1)
+  }
+  
+  sdf
 }
 ```
 
-## Option B — Smoothed covariance
+```{r pointwise-plot, fig.width=10, fig.height=9}
+# Build data for all subjects
+plot_data <- do.call(rbind, lapply(1:ntest, function(i) {
+  d <- build_subject_df(i, RLTPred, SurvMat)
+  d$subject <- paste("Subject", i)
+  d
+}))
 
-This option builds smoothed bands which can be more stable.
-Here we use a small rank for illustration.
+ggplot(plot_data, aes(x = time)) +
+  facet_wrap(~ subject, nrow = 2, scales = "free_y") +
+  # Pointwise band (shaded)
+  geom_ribbon(aes(ymin = lower_pw, ymax = upper_pw),
+              fill = "grey80", alpha = 0.6) +
+  # Truth
+  geom_line(aes(y = truth, colour = "True S(t)"), linewidth = 0.9, linetype = "dashed") +
+  # Estimate
+  geom_step(aes(y = surv, colour = "Estimated S(t)"), linewidth = 0.9) +
+  scale_colour_manual(name = NULL,
+                      values = c("True S(t)" = "#E41A1C", "Estimated S(t)" = "#222222")) +
+  scale_y_continuous(limits = c(0, 1), expand = c(0.01, 0.01)) +
+  labs(x = "Time", y = "Survival Probability",
+       title = "Pointwise 95% Confidence Intervals") +
+  theme_minimal(base_size = 13) +
+  theme(legend.position = "bottom",
+        panel.grid.minor = element_blank(),
+        strip.text = element_text(face = "bold"))
+```
 
-```{r smoothed-bands, fig.width=10, fig.height=8}
-alpha <- 0.05
-logt  <- log(1 + timepoints)
+## Simultaneous confidence band
 
-SurvBand_B <- get.surv.band(RLTPred, alpha = alpha, approach = "smoothed", k_rank = 5)
+`get.surv.band()` with `approach = "smoothed"` constructs a simultaneous confidence band using a GAM-smoothed low-rank approximation of the covariance matrix, plus an eigenvalue-ratio weighted residual correction. The smoothed approach is more stable than the naive Monte Carlo method, especially when the number of time points is large.
 
-layout(matrix(1:ntest, nrow = 2, byrow = TRUE))
-par(mar = c(3, 3, 2, 1))
-for (i in 1:ntest) {
-  plot(logt, SurvMat[i, ], type = "l", lwd = 2, col = "red",
-       xlab = "log(1 + time)", ylab = paste("Subject", i),
-       ylim = c(0, 1))
-  lines(logt, RLTPred$Survival[i, ], lwd = 2, col = "black")
-  lines(logt, RLTPred$Survival[i, ] - qnorm(1 - alpha/2) * sqrt(diag(RLTPred$Cov[,, i])),
-        lty = 2, col = "black")
-  lines(logt, RLTPred$Survival[i, ] + qnorm(1 - alpha/2) * sqrt(diag(RLTPred$Cov[,, i])),
-        lty = 2, col = "black")
-  lines(logt, as.numeric(SurvBand_B[[i]]$lower), lty = 3, lwd = 2, col = "deepskyblue")
-  lines(logt, as.numeric(SurvBand_B[[i]]$upper), lty = 3, lwd = 2, col = "deepskyblue")
-}
+```{r band-calc}
+SurvBand <- get.surv.band(RLTPred, alpha = 0.05, approach = "smoothed", k_rank = 10)
+```
+
+```{r band-plot, fig.width=10, fig.height=9}
+plot_band <- do.call(rbind, lapply(1:ntest, function(i) {
+  d <- build_subject_df(i, RLTPred, SurvMat, SurvBand)
+  d$subject <- paste("Subject", i)
+  d
+}))
+
+ggplot(plot_band, aes(x = time)) +
+  facet_wrap(~ subject, nrow = 2, scales = "free_y") +
+  # Simultaneous band (blue shading)
+  geom_ribbon(aes(ymin = lower_band, ymax = upper_band),
+              fill = "#3B82F6", alpha = 0.25) +
+  # Pointwise band (grey shading, for comparison)
+  geom_ribbon(aes(ymin = lower_pw, ymax = upper_pw),
+              fill = "grey70", alpha = 0.3) +
+  # Truth
+  geom_line(aes(y = truth, colour = "True S(t)"), linewidth = 0.9, linetype = "dashed") +
+  # Estimate
+  geom_step(aes(y = surv, colour = "Estimated S(t)"), linewidth = 0.9) +
+  scale_colour_manual(name = NULL,
+                      values = c("True S(t)" = "#E41A1C", "Estimated S(t)" = "#222222")) +
+  scale_y_continuous(limits = c(0, 1), expand = c(0.01, 0.01)) +
+  labs(x = "Time", y = "Survival Probability",
+       title = "Smoothed Covariance — 95% Simultaneous Confidence Band",
+       subtitle = "Grey = pointwise CI; Blue = simultaneous band") +
+  theme_minimal(base_size = 13) +
+  theme(legend.position = "bottom",
+        panel.grid.minor = element_blank(),
+        strip.text = element_text(face = "bold"))
 ```
 
 ## (Optional) Proportion-selected smoothing
 
-For completeness, the smoothed approach can choose the rank by cumulative eigenvalue proportion:
+The smoothed approach can also choose the rank by cumulative eigenvalue proportion instead of a fixed `k_rank`:
 
 ```r
-SurvBand_C <- get.surv.band(
+SurvBand_prop <- get.surv.band(
   RLTPred, alpha = 0.05,
   approach = "smoothed",
   k_mode = "proportion",
@@ -159,4 +196,11 @@ SurvBand_C <- get.surv.band(
 
 You can increase `nsim` for stability at the cost of runtime.
 
+## (Optional) Reducing the time grid
 
+For large datasets, the full set of failure times can make covariance matrices unwieldy. Use `band.grid.size` in `predict()` to evaluate variance on a reduced quantile-based grid:
+
+```r
+pred_reduced <- predict(fit, testX, var.est = TRUE, band.grid.size = 50)
+length(pred_reduced$timepoints)  # <= 50 time points
+```


### PR DESCRIPTION
## Summary

Major rewrite of the survival confidence-interval vignette (`vignettes/articles/confidence-interval.Rmd`).

### Changes
- **Default to smoothed approach** — removed the naive Monte Carlo band section entirely; the smoothed covariance method is now the only band method demonstrated
- **ggplot2 throughout** — replaced all base R plots with publication-quality ggplot2 figures (shaded ribbons, facets, clean styling)
- **Bands clamped to [0,1]** — survival confidence bands can naturally exceed [0,1] via the CHF→survival transform; now clamped in plotting code
- **1000 trees** — increased from 200 for stable variance estimation
- **Streamlined** — removed the side-by-side comparison plot and duplicate prose

### Why
The original vignette used basic base R plots, showed survival bands exceeding 1.6 (invalid probabilities), and the naive band section was less stable than the smoothed approach. The rewrite presents only the recommended method with clean, publication-ready visuals.