### PR TITLE
Add badges to README: CRAN version, downloads, GitHub version, CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # RLT
 
+[![CRAN Version](https://www.r-pkg.org/badges/version/RLT)](https://cran.r-project.org/package=RLT)
+[![CRAN Downloads](https://cranlogs.r-pkg.org/badges/grand-total/RLT?color=blue)](https://cran.r-project.org/package=RLT)
+[![GitHub Version](https://img.shields.io/github/r-package/v/teazrq/RLT?label=GitHub&color=brightgreen)](https://github.com/teazrq/RLT)
+[![R build status](https://github.com/teazrq/RLT/actions/workflows/pkgdown.yaml/badge.svg)](https://github.com/teazrq/RLT/actions)
+
 **Reinforcement Learning Trees** is an R package for random forest models with
 regression, classification, and survival analysis support. The package uses a
 C++/Rcpp backend with OpenMP for parallel computation.


### PR DESCRIPTION
## Summary

Adds status badges to the top of `README.md`:

- **CRAN Version** — links to the CRAN page, shows current release version
- **CRAN Downloads** — grand total download count from CRAN
- **GitHub Version** — shows the latest GitHub release/tag version
- **CI Build Status** — links to the pkgdown Actions workflow

No code changes — README only.