### PR TITLE
Fix survival output: derive from CHF for consistent confidence bands

### DIFF
--- a/src/r-interface/SurvUniForest.cpp
+++ b/src/r-interface/SurvUniForest.cpp
@@ -212,10 +212,11 @@ List SurvUniForestPred(arma::field<arma::ivec>& SplitVar,
       mat pred_i_hazard_reduced = pred_i_hazard_full.cols(mapping_indices);
       mat pred_i_survival_reduced = pred_i_survival_full.cols(mapping_indices);
 
-      // 4. Assign the mean of the reduced hazard and survival matrices to the output
+      // 4. Assign the mean hazard, then derive CHF and Survival consistently.
+      //    Survival = exp(-CHF) ensures the band exp(-CHF ± bandk) centers on Surv.
       Hazard.row(i) = mean(pred_i_hazard_reduced, 0);
-      Surv.row(i) = mean(pred_i_survival_reduced, 0);
       CHazard.row(i) = cumsum(Hazard.row(i));
+      Surv.row(i) = exp(-CHazard.row(i));
 
       // 5. Variance estimation using standalone functions
       //    Variance is computed on the CHF (cumulative hazard) scale,


### PR DESCRIPTION
## Problem

The survival prediction output uses two inconsistent estimators:
- `Surv = mean(per-tree survival)` (product-path)
- `CHF = cumsum(mean hazard)` (sum-path)

Since `mean(S) ≠ exp(-cumsum(mean(H)))`, the confidence band `exp(-CHF ± bandk)` does **not** always bound the `Survival` curve — the band can cross above or below it.

## Fix

Derive `Surv` from `CHF` directly: `Surv = exp(-CHF)`. Since `exp(-·)` is monotone, `exp(-CHF - bandk) ≤ exp(-CHF) ≤ exp(-CHF + bandk)` always holds, guaranteeing `lower ≤ Surv ≤ upper`.

## Change

`src/r-interface/SurvUniForest.cpp` — 1 line changed:
```cpp
// Before
Surv.row(i) = mean(pred_i_survival_reduced, 0);
// After
Surv.row(i) = exp(-CHazard.row(i));
```

`Hazard` and `CHF` are unchanged. All variance estimation (matched/IJ/jackknife) is unaffected since it operates on the CHF scale anyway.